### PR TITLE
Removing static classes

### DIFF
--- a/app/SmartFlowUI/backend/AppConfiguration.cs
+++ b/app/SmartFlowUI/backend/AppConfiguration.cs
@@ -1,79 +1,86 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Text.Json.Serialization;
+
 namespace MinimalApi;
 
-public static class AppConfiguration
+public class AppConfiguration
 {
-    public static int SearchIndexDocumentCount { get; private set; }
+    public string DataProtectionKeyContainer { get; private set; } = "dataprotectionkeys";
 
-    public static string AzureStorageAccountConnectionString { get; private set; }
+    public bool EnableDataProtectionBlobKeyStorage { get; private set; }
 
-    public static string DataProtectionKeyContainer { get; private set; }
+    public string UserDocumentUploadBlobStorageContentContainer { get; private set; } = "content";
+    public string UserDocumentUploadBlobStorageExtractContainer { get; private set; } = "content-extract";
 
-    public static bool EnableDataProtectionBlobKeyStorage { get; private set; }
+    public int Port { get; private set; } = 8080;
 
-    public static string UserDocumentUploadBlobStorageContentContainer { get; private set; }
-    public static string UserDocumentUploadBlobStorageExtractContainer { get; private set; }
+    public int SearchIndexDocumentCount { get; init; } = 15;
 
-    public static int Port { get; private set; }
+    public bool UseManagedIdentityResourceAccess { get; init; }
+    public string UserAssignedManagedIdentityClientId { get; init; }
 
-    public static void Load(IConfiguration configuration)
-    {
-        SearchIndexDocumentCount = configuration.GetValue<int>("SearchIndexDocumentCount", 15);
-
-        AzureStorageAccountConnectionString = configuration.GetValue<string>("AzureStorageAccountConnectionString");
-        DataProtectionKeyContainer = configuration.GetValue<string>("SearchIndexSourceFieldName", "dataprotectionkeys");
-        EnableDataProtectionBlobKeyStorage = configuration.GetValue<bool>("EnableDataProtectionBlobKeyStorage", true);
-
-        UserDocumentUploadBlobStorageContentContainer = configuration.GetValue<string>("UserDocumentUploadBlobStorageContentContainer", "content");
-
-        UserDocumentUploadBlobStorageExtractContainer = configuration.GetValue<string>("UserDocumentUploadBlobStorageExtractContainer", "content-extract");
-        Port = configuration.GetValue<int>("PORT", 8080);
-    }
-}
-
-public static class AppConfigurationSetting
-{
-    public static string UseManagedIdentityResourceAccess { get; } = "UseManagedIdentityResourceAccess";
-    public static string UserAssignedManagedIdentityClientId { get; } = "UserAssignedManagedIdentityClientId";
 
     // CosmosDB
-    public static string CosmosDbEndpoint { get; } = "CosmosDbEndpoint";
-    public static string CosmosDBConnectionString { get; } = "CosmosDBConnectionString";
+    public string? CosmosDbEndpoint { get; init; }
+
+    public string? CosmosDBConnectionString { get; init; }
+
 
     // Azure Search
-    public static string AzureSearchServiceEndpoint { get; } = "AzureSearchServiceEndpoint";
-    public static string AzureSearchServiceKey { get; } = "AzureSearchServiceKey";
-    public static string AzureSearchServiceIndexName { get; } = "AzureSearchIndexName";
+    public string? AzureSearchServiceEndpoint { get; init; }
+
+    public string? AzureSearchServiceKey { get; init; }
+
+    public string? AzureSearchServiceIndexName { get; init; }
+
 
     // Azure Storage
-    public static string AzureStorageAccountEndpoint { get; } = "AzureStorageAccountEndpoint";
-    public static string AzureStorageAccountConnectionString { get; } = "AzureStorageAccountConnectionString";
-    public static string AzureStorageUserUploadContainer { get; } = "AzureStorageUserUploadContainer";
-    public static string AzureStorageContainer { get; } = "AzureStorageContainer";
+    public string AzureStorageAccountEndpoint { get; init; }
+    public string AzureStorageAccountConnectionString { get; init; }
 
-    public static string DocumentUploadStrategy { get; } = "DocumentUploadStrategy";
+    public string AzureStorageUserUploadContainer { get; init; }
+
+    public string AzureStorageContainer { get; init; }
+
+
+    public string DocumentUploadStrategy { get; init; } = "AzureNative";
 
 
     // Ingestion Pipeline
-    public static string IngestionPipelineAPI { get; } = "IngestionPipelineAPI";
-    public static string IngestionPipelineAPIKey { get; } = "IngestionPipelineAPIKey";
+    public string? IngestionPipelineAPI { get; init; }
 
-    public static string Port { get; } = "PORT";
+    public string IngestionPipelineAPIKey { get; init; }
 
-    public static string ApplicationInsightsConnectionString { get; } = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+    [JsonPropertyName("APPLICATIONINSIGHTS_CONNECTION_STRING")]
+    public string? ApplicationInsightsConnectionString { get; set; }
 
     // On-Behalf-Of (OBO) Flow
-    public static string AzureServicePrincipalClientID { get; } = "AZURE_SP_CLIENT_ID";
-    public static string AzureServicePrincipalClientSecret { get; } = "AZURE_SP_CLIENT_SECRET";
-    public static string AzureTenantID { get; } = "AZURE_TENANT_ID";
-    public static string AzureAuthorityHost { get; } = "AZURE_AUTHORITY_HOST";
-    public static string AzureServicePrincipalOpenAIAudience { get; } = "AZURE_SP_OPENAI_AUDIENCE";
-    public static string OcpApimSubscriptionKey { get; } = "Ocp-Apim-Subscription-Key";
-    public static string XMsTokenAadAccessToken { get; } = "X-MS-TOKEN-AAD-ACCESS-TOKEN";
-    public static string AOAIStandardChatGptDeployment { get; } = "AOAIStandardChatGptDeployment";
-    public static string AOAIStandardServiceEndpoint { get; } = "AOAIStandardServiceEndpoint";
-    public static string AOAIPremiumChatGptDeployment { get; } = "AOAIPremiumChatGptDeployment";
-    public static string AOAIPremiumServiceEndpoint { get; } = "AOAIPremiumServiceEndpoint";
+    [JsonPropertyName("AZURE_SP_CLIENT_ID")]
+    public string? AzureServicePrincipalClientID { get; set; }
+    [JsonPropertyName("AZURE_SP_CLIENT_SECRET")]
+    public string? AzureServicePrincipalClientSecret { get; set; }
+    [JsonPropertyName("AZURE_TENANT_ID")]
+    public string? AzureTenantID { get; set; }
+    [JsonPropertyName("AZURE_AUTHORITY_HOST")]
+    public string? AzureAuthorityHost { get; set; }
+    [JsonPropertyName("AZURE_SP_OPENAI_AUDIENCE")]
+    public string? AzureServicePrincipalOpenAIAudience { get; set; }
+    public string OcpApimSubscriptionHeaderName { get; init; } = "Ocp-Apim-Subscription-Key";
+    public string OcpApimSubscriptionKey { get; init; } = "Ocp-Apim-Subscription-Key";
+    public string XMsTokenAadAccessToken { get; init; } = "X-MS-TOKEN-AAD-ACCESS-TOKEN";
+    public string? AOAIStandardChatGptDeployment { get; init; }
+    public string? AOAIStandardServiceEndpoint { get; init; }
+    public string? AOAIStandardServiceKey { get; init; }
+    public string? AOAIPremiumChatGptDeployment { get; init; }
+    public string? AOAIPremiumServiceEndpoint { get; init; }
+    public string? AOAIPremiumServiceKey { get; init; }
 
+    public string AOAIEmbeddingsDeployment { get; init; } = string.Empty;
+
+    // Profile configuration
+    public string? ProfileConfigurationBlobStorageContainer { get; init; }
+    public string? ProfileConfiguration { get; init; }
+    public string ProfileFileName { get; init; } = "profiles";
 }

--- a/app/SmartFlowUI/backend/Extensions/SKExtensions.cs
+++ b/app/SmartFlowUI/backend/Extensions/SKExtensions.cs
@@ -91,35 +91,36 @@ public static class SKExtensions
         return value.ToLower() == "true";
     }
 
-    public static bool IsChatProfile(this Dictionary<string, string> options)
+    public static bool IsChatProfile(this Dictionary<string, string> options, List<ProfileDefinition> profiles)
     {
-        var profile = options.GetChatProfile();
-        var selected = ProfileDefinition.All.FirstOrDefault(x => x.Name == profile.Name);
+        var profile = options.GetChatProfile(profiles);
+        var selected = profiles.FirstOrDefault(x => x.Name == profile.Name);
         return selected?.Approach.ToUpper() == "CHAT";
     }
-    public static bool IsEndpointAssistantProfile(this Dictionary<string, string> options)
+
+    public static bool IsEndpointAssistantProfile(this Dictionary<string, string> options, List<ProfileDefinition> profiles)
     {
-        var profile = options.GetChatProfile();
-        var selected = ProfileDefinition.All.FirstOrDefault(x => x.Name == profile.Name);
+        var profile = options.GetChatProfile(profiles);
+        var selected = profiles.FirstOrDefault(x => x.Name == profile.Name);
         return selected?.Approach.ToUpper() == "ENDPOINTASSISTANT";
     }
-    public static bool IsEndpointAssistantV2Profile(this Dictionary<string, string> options)
+    public static bool IsEndpointAssistantV2Profile(this Dictionary<string, string> options, List<ProfileDefinition> profiles)
     {
-        var profile = options.GetChatProfile();
-        var selected = ProfileDefinition.All.FirstOrDefault(x => x.Name == profile.Name);
+        var profile = options.GetChatProfile(profiles);
+        var selected = profiles.FirstOrDefault(x => x.Name == profile.Name);
         return selected?.Approach.ToUpper() == "ENDPOINTASSISTANTV2";
     }
-    public static bool IsEndpointAssistantTaskProfile(this Dictionary<string, string> options)
+    public static bool IsEndpointAssistantTaskProfile(this Dictionary<string, string> options, List<ProfileDefinition> profiles)
     {
-        var profile = options.GetChatProfile();
-        var selected = ProfileDefinition.All.FirstOrDefault(x => x.Name == profile.Name);
+        var profile = options.GetChatProfile(profiles);
+        var selected = profiles.FirstOrDefault(x => x.Name == profile.Name);
         return selected?.Approach.ToUpper() == "ENDPOINTASSISTANTTASK";
     }
-    public static ProfileDefinition GetChatProfile(this Dictionary<string, string> options)
+    public static ProfileDefinition GetChatProfile(this Dictionary<string, string> options, List<ProfileDefinition> profiles)
     {
-        var defaultProfile = ProfileDefinition.All.First();
+        var defaultProfile = profiles.First();
         var value = options.GetValueOrDefault("PROFILE", defaultProfile.Name);
-        return ProfileDefinition.All.FirstOrDefault(x => x.Name == value) ?? defaultProfile;
+        return profiles.FirstOrDefault(x => x.Name == value) ?? defaultProfile;
     }
 
     public static string? GetImageContent(this Dictionary<string, string> options)

--- a/app/SmartFlowUI/backend/MinimalApi.csproj
+++ b/app/SmartFlowUI/backend/MinimalApi.csproj
@@ -72,6 +72,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/app/SmartFlowUI/backend/Services/ChatHistory/ChatHistoryExtension.cs
+++ b/app/SmartFlowUI/backend/Services/ChatHistory/ChatHistoryExtension.cs
@@ -6,14 +6,14 @@ namespace MinimalApi.Services.ChatHistory;
 
 public static class ChatHistoryExtension
 {
-    public static List<ChatHistoryResponse> AsFeedbackResponse(this List<ChatMessageRecord> records)
+    public static List<ChatHistoryResponse> AsFeedbackResponse(this List<ChatMessageRecord> records, ProfileInfo profileInfo)
     {
         var chatHistoryResponses = new List<ChatHistoryResponse>();
 
         foreach (var item in records)
         {
             var profileName = item.Context?.Profile ?? "Unavailable";
-            var profileId = ProfileDefinition.All.SingleOrDefault(x => x.Name == profileName)?.Id ?? "Unavailable";
+            var profileId = profileInfo.Profiles.SingleOrDefault(x => x.Name == profileName)?.Id ?? "Unavailable";
 
             var rating = item.Rating?.Rating ?? 0;
             var feedback = item.Rating?.Feedback ?? string.Empty;

--- a/app/SmartFlowUI/backend/Services/HealthChecks/AzureStorageReadinessHealthCheck.cs
+++ b/app/SmartFlowUI/backend/Services/HealthChecks/AzureStorageReadinessHealthCheck.cs
@@ -4,13 +4,15 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace MinimalApi.Services.HealthChecks;
 
-public class AzureStorageReadinessHealthCheck(BlobServiceClient blobServiceClient) : IHealthCheck
+public class AzureStorageReadinessHealthCheck(BlobServiceClient blobServiceClient, AppConfiguration configuration) : IHealthCheck
 {
     private readonly BlobServiceClient _blobServiceClient = blobServiceClient;
+    private readonly AppConfiguration _configuration = configuration;
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-       Dictionary<string, object> data = [];
+        Dictionary<string, object> data = [];
+        var containerName = _configuration.UserDocumentUploadBlobStorageContentContainer;
 
 #pragma warning disable CA1031 // Do not catch general exception types
         try
@@ -29,14 +31,14 @@ public class AzureStorageReadinessHealthCheck(BlobServiceClient blobServiceClien
 #pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            var containerClient = _blobServiceClient.GetBlobContainerClient(AppConfiguration.UserDocumentUploadBlobStorageContentContainer);
+            var containerClient = _blobServiceClient.GetBlobContainerClient(_configuration.UserDocumentUploadBlobStorageContentContainer);
             await containerClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            data.Add("Container", $"Container is accessible: {AppConfiguration.UserDocumentUploadBlobStorageContentContainer}");
+            data.Add("Container", $"Container is accessible: {_configuration.UserDocumentUploadBlobStorageContentContainer}");
         }
         catch (Exception ex)
         {
-            data.Add("Container", $"Container is accessible: {AppConfiguration.UserDocumentUploadBlobStorageContentContainer}");
+            data.Add("Container", $"Container is accessible: {_configuration.UserDocumentUploadBlobStorageContentContainer}");
             return new HealthCheckResult(HealthStatus.Unhealthy, description: "Storage Account is not accessible", exception: ex, data: data);
         }
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/app/SmartFlowUI/backend/Services/Search/IngestionService.cs
+++ b/app/SmartFlowUI/backend/Services/Search/IngestionService.cs
@@ -7,18 +7,18 @@ public class IngestionService
 {
     private readonly AzureBlobStorageService _blobStorageService;
     private readonly HttpClient _httpClient;
-    private readonly IConfiguration _configuration;
+    private readonly AppConfiguration _configuration;
 
-    public IngestionService(AzureBlobStorageService blobStorageService, HttpClient httpClient, IConfiguration configuration)
+    public IngestionService(AzureBlobStorageService blobStorageService, HttpClient httpClient, AppConfiguration configuration)
     {
         _blobStorageService = blobStorageService;
 
-        if (configuration[AppConfigurationSetting.IngestionPipelineAPI] != null)
+        if (configuration.IngestionPipelineAPI != null)
         {
             _httpClient = httpClient;
 
-            _httpClient.BaseAddress = new Uri(configuration[AppConfigurationSetting.IngestionPipelineAPI]);
-            _httpClient.DefaultRequestHeaders.Add("x-functions-key", configuration[AppConfigurationSetting.IngestionPipelineAPIKey]);
+            _httpClient.BaseAddress = new Uri(configuration.IngestionPipelineAPI);
+            _httpClient.DefaultRequestHeaders.Add("x-functions-key", configuration.IngestionPipelineAPIKey);
             _httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
             _configuration = configuration;
         }
@@ -81,10 +81,10 @@ public class IngestionService
         var json = System.Text.Json.JsonSerializer.Serialize(request, SerializerOptions.Default);
         using var body = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var httpRequest = new HttpRequestMessage
+        using var httpRequest = new HttpRequestMessage
         {
             Method = HttpMethod.Get,
-            RequestUri = new Uri($"{_configuration[AppConfigurationSetting.IngestionPipelineAPI]}/api/get_active_index"),
+            RequestUri = new Uri($"{_configuration.IngestionPipelineAPI}/api/get_active_index"),
             Content = body
         };
 

--- a/app/SmartFlowUI/backend/Services/Search/SearchClientFactory.cs
+++ b/app/SmartFlowUI/backend/Services/Search/SearchClientFactory.cs
@@ -10,13 +10,13 @@ namespace MinimalApi.Services.Search;
 
 public class SearchClientFactory
 {
-    private readonly IConfiguration _configuration;
+    private readonly AppConfiguration _configuration;
     private readonly ConcurrentDictionary<string,SearchClient> _clients = new ConcurrentDictionary<string, SearchClient>();
-    private readonly TokenCredential _credential;
+    private readonly TokenCredential? _credential;
     private readonly AzureKeyCredential? _keyCredential;
     private readonly SearchIndexerClient _searchIndexerClient;
 
-    public SearchClientFactory(IConfiguration configuration, TokenCredential credential, AzureKeyCredential? keyCredential = null)
+    public SearchClientFactory(AppConfiguration configuration, TokenCredential? credential, AzureKeyCredential? keyCredential = null)
     {
         _configuration = configuration;
         _credential = credential;
@@ -42,9 +42,9 @@ public class SearchClientFactory
     {
         if (_keyCredential != null)
         {
-            return new SearchClient(new Uri(_configuration[AppConfigurationSetting.AzureSearchServiceEndpoint]), indexName, _keyCredential);
+            return new SearchClient(new Uri(_configuration.AzureSearchServiceEndpoint), indexName, _keyCredential);
         }
-        return new SearchClient(new Uri(_configuration[AppConfigurationSetting.AzureSearchServiceEndpoint]), indexName, _credential);
+        return new SearchClient(new Uri(_configuration.AzureSearchServiceEndpoint), indexName, _credential);
     }
 
     public SearchIndexerClient GetSearchIndexerClient()
@@ -56,8 +56,8 @@ public class SearchClientFactory
     {
         if (_keyCredential != null)
         {
-            return new SearchIndexerClient(new Uri(_configuration[AppConfigurationSetting.AzureSearchServiceEndpoint]), _keyCredential);
+            return new SearchIndexerClient(new Uri(_configuration.AzureSearchServiceEndpoint), _keyCredential);
         }
-        return new SearchIndexerClient(new Uri(_configuration[AppConfigurationSetting.AzureSearchServiceEndpoint]), _credential);
+        return new SearchIndexerClient(new Uri(_configuration.AzureSearchServiceEndpoint), _credential);
     }
 }

--- a/app/SmartFlowUI/backend/Services/Skills/RetrieveRelatedDocumentSkill.cs
+++ b/app/SmartFlowUI/backend/Services/Skills/RetrieveRelatedDocumentSkill.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel;
-using MinimalApi.Services.Profile;
-using MinimalApi.Services.Search;
 using MinimalApi.Services.Search.IndexDefinitions;
 
 
@@ -10,13 +8,13 @@ namespace MinimalApi.Services.Skills;
 
 public sealed class RetrieveRelatedDocumentSkill
 {
-    private readonly IConfiguration _config;
+    private readonly AppConfiguration _configuration;
     private readonly SearchClientFactory _searchClientFactory;
     private readonly AzureOpenAIClient _openAIClient;
 
-    public RetrieveRelatedDocumentSkill(IConfiguration config, SearchClientFactory searchClientFactory, AzureOpenAIClient openAIClient)
+    public RetrieveRelatedDocumentSkill(AppConfiguration config, SearchClientFactory searchClientFactory, AzureOpenAIClient openAIClient)
     {
-        _config= config;
+        _configuration= config;
         _searchClientFactory = searchClientFactory;
         _openAIClient = openAIClient;
     }
@@ -57,7 +55,7 @@ public sealed class RetrieveRelatedDocumentSkill
                 arguments[ContextVariableOptions.SelectedFilters] = sb.ToString();
         }
 
-        var searchLogic = ResolveRetrievalLogic(_openAIClient, _searchClientFactory, profile.RAGSettings, _config["AOAIEmbeddingsDeployment"], profile.RAGSettings.DocumentRetrievalPluginQueryFunctionName);
+        var searchLogic = ResolveRetrievalLogic(_openAIClient, _searchClientFactory, profile.RAGSettings, _configuration.AOAIEmbeddingsDeployment, profile.RAGSettings.DocumentRetrievalPluginQueryFunctionName);
         var result = await searchLogic(searchQuery, arguments);
 
         if (!result.Sources.Any())
@@ -109,12 +107,5 @@ public sealed class RetrieveRelatedDocumentSkill
         throw new InvalidOperationException("Invalid search implementation.");
     }
 
-    private static int ResolveDocumentCount(int documentRetrievalDocumentCount)
-    {
-        if (documentRetrievalDocumentCount > 0)
-        {
-            return documentRetrievalDocumentCount;
-        }
-        return AppConfiguration.SearchIndexDocumentCount;
-    }
+    private int ResolveDocumentCount(int documentRetrievalDocumentCount) => documentRetrievalDocumentCount > 0 ? documentRetrievalDocumentCount : _configuration.SearchIndexDocumentCount;
 }

--- a/app/SmartFlowUI/frontend/Program.cs
+++ b/app/SmartFlowUI/frontend/Program.cs
@@ -7,12 +7,13 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Configuration.AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true);
 
 builder.Services.Configure<AppSettings>(
-builder.Configuration.GetSection(nameof(AppSettings)));
+    builder.Configuration.GetSection(nameof(AppSettings))
+);
 builder.Services.AddHttpClient<ApiClient>(client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) , Timeout= TimeSpan.FromMinutes(5) });
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress), Timeout = TimeSpan.FromMinutes(5) });
 builder.Services.AddLocalStorageServices();
 builder.Services.AddSessionStorageServices();
 builder.Services.AddMudServices();

--- a/app/SmartFlowUI/shared/Shared/Models/ProfileDefinition.cs
+++ b/app/SmartFlowUI/shared/Shared/Models/ProfileDefinition.cs
@@ -4,7 +4,6 @@ namespace Shared.Models;
 
 public class ProfileDefinition
 {
-    public static List<ProfileDefinition> All;
     public ProfileDefinition()
     {
         Name = "Undefined";
@@ -13,7 +12,15 @@ public class ProfileDefinition
     {
         Name = name;
     }
-    public ProfileDefinition(string name, string id, string approach, string securityModel, List<string> securityModelGroupMembership, List<string> sampleQuestions, RAGSettingsSummary? ragSettingsSummary, AssistantEndpointSettingsSummary? assistantEndpointSettingsSummary)
+    public ProfileDefinition(
+        string name,
+        string id,
+        string approach,
+        string securityModel,
+        List<string> securityModelGroupMembership,
+        List<string> sampleQuestions,
+        RAGSettingsSummary? ragSettingsSummary,
+        AssistantEndpointSettingsSummary? assistantEndpointSettingsSummary)
     {
         Name = name;
         Id = id;


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `AppConfiguration` class and updating method signatures to use the new configuration class. It also includes changes to improve dependency injection and configuration management.

### Refactoring and Configuration Management:

* [`app/SmartFlowUI/backend/AppConfiguration.cs`](diffhunk://#diff-08af4e4aa60c772d6bdc711e6d0e28176b0a5cb9fc5e6b801fc1382d0d72d259R3-R85): Refactored `AppConfiguration` from a static class to an instance class, added new properties, and removed the `Load` method. Introduced `JsonPropertyName` attributes for certain properties.

### Method Signature Updates:

* [`app/SmartFlowUI/backend/Extensions/SKExtensions.cs`](diffhunk://#diff-838f787b1585f4486b77b53486168d2ad77b4ebca2f21e77d80db4b2376bb8fcL94-R123): Updated method signatures in `IsChatProfile`, `IsEndpointAssistantProfile`, `IsEndpointAssistantV2Profile`, `IsEndpointAssistantTaskProfile`, and `GetChatProfile` to accept a `List<ProfileDefinition>` parameter.

### Dependency Injection and Azure Services:

* [`app/SmartFlowUI/backend/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1R19-R68): Updated `AddAzureServices` and `AddAzureWithMICredentialsServices` methods to use the new `AppConfiguration` class. Improved the setup of Azure services and clients, including BlobServiceClient, OpenAIClientFacade, and SearchClientFactory. [[1]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1R19-R68) [[2]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L89-R81) [[3]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L157-R154) [[4]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L177-R176) [[5]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L198-R206) [[6]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L231-R219) [[7]](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L241-R228)