### PR TITLE
Refactor Azure credential handling

### DIFF
--- a/app/SmartFlowUI/backend/AppConfiguration.cs
+++ b/app/SmartFlowUI/backend/AppConfiguration.cs
@@ -19,6 +19,7 @@ public class AppConfiguration
 
     public bool UseManagedIdentityResourceAccess { get; init; }
     public string UserAssignedManagedIdentityClientId { get; init; }
+    public string VisualStudioTenantId { get; init; }
 
 
     // CosmosDB


### PR DESCRIPTION
If you are developing with Visual Studio locally and are trying to use your identity to get access to Azure resources and get the error message:
`Provided AAD token was issued by the authority [x] which is not trusted by this database account. Please ensure the token has been issued by the AAD tenant(s) [y].` 
or 
`Token tenant [x] does not match resource tenant.`
then your current Visual Studio user is using the wrong tenant.

This fix allows you to create a secret or appSetting with the name `VisualStudioTenantId` and then the application will get the tokens using that tenant.

---

This pull request introduces changes to the `AppConfiguration` class and the `ServiceCollectionExtensions` to support the use of a Visual Studio tenant ID for Azure credentials. The most important changes include adding a new property to the `AppConfiguration` class and updating the Azure service registration logic to handle the new property.

Enhancements to Azure service configuration:

* [`app/SmartFlowUI/backend/AppConfiguration.cs`](diffhunk://#diff-08af4e4aa60c772d6bdc711e6d0e28176b0a5cb9fc5e6b801fc1382d0d72d259R22): Added a new property `VisualStudioTenantId` to the `AppConfiguration` class.
* [`app/SmartFlowUI/backend/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1R32-R53): Updated the `AddAzureServices` method to use `VisualStudioTenantId` if it is provided, falling back to `UserAssignedManagedIdentityClientId` or default credentials otherwise.
* [`app/SmartFlowUI/backend/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-34eab9e1d5959c2b05e676d331217091c5a5bab6894920c6b09e8c71325a9cc1L169-R201): Modified the `AddAzureWithMICredentialsServices` method to include logic for using `VisualStudioTenantId` in the credential options.