### PR TITLE
Add error catch to question rendering component

### DIFF
--- a/app/SmartFlowUI/frontend/Components/Question.razor.cs
+++ b/app/SmartFlowUI/frontend/Components/Question.razor.cs
@@ -15,7 +15,7 @@ public sealed partial class Question
 
     protected override void OnParametersSet()
     {
-        _userAnswerHTML = Markdown.ToHtml(UserQuestion, s_pipeline);
+        _userAnswerHTML = !string.IsNullOrEmpty(UserQuestion) ? Markdown.ToHtml(UserQuestion, s_pipeline) : string.Empty;
 
         base.OnParametersSet();
     }


### PR DESCRIPTION
This pull request includes a small but significant change to the `Question` class in the `Question.razor.cs` file. The change ensures that the `_userAnswerHTML` field is set to an empty string if `UserQuestion` is null or empty, preventing potential issues with null values.

* [`app/SmartFlowUI/frontend/Components/Question.razor.cs`](diffhunk://#diff-9b7c88548c048cbc6995fddac44ac41c8e137f523a0a2697a80c9d4ead3a88dbL18-R18): Updated the `_userAnswerHTML` assignment to handle null or empty `UserQuestion` values by setting `_userAnswerHTML` to an empty string if `UserQuestion` is null or empty.